### PR TITLE
修复点播rtmp时多出一个后缀名的bug

### DIFF
--- a/src/Rtmp/RtmpSession.cpp
+++ b/src/Rtmp/RtmpSession.cpp
@@ -380,7 +380,12 @@ string RtmpSession::getStreamId(const string &str){
         //vlc和ffplay在播放 rtmp://127.0.0.1/record/0.mp4时，
         //传过来的url会是rtmp://127.0.0.1/record/mp4:0,
         //我们在这里还原成0.mp4
-        stream_id = stream_id.substr(pos + 1) + "." + stream_id.substr(0,pos);
+        //实际使用时发现vlc，mpv等会传过来rtmp://127.0.0.1/record/mp4:0.mp4,这里做个判断
+        auto ext = stream_id.substr(0,pos);
+        stream_id = stream_id.substr(pos + 1);
+        if(stream_id.find(ext) == string::npos){
+            stream_id = stream_id + "." + ext;
+        }
     }
 
     if(params.empty()){


### PR DESCRIPTION
vlc，mpv等播放rtmp时的url规则与代码中注释的不同，导致出现2个后缀名